### PR TITLE
Compatibilidade com Java 7 e seleção do IModelRetriever.

### DIFF
--- a/AOMRoleMapper/src/org/esfinge/aom/manager/ModelManager.java
+++ b/AOMRoleMapper/src/org/esfinge/aom/manager/ModelManager.java
@@ -36,16 +36,21 @@ public class ModelManager {
 	
 	public static ModelManager getInstance()
 	{
+		return getInstance(null);
+	}
+	
+	public static ModelManager getInstance(String managerName)
+	{
 		if (instance == null)
 		{
-			instance = new ModelManager();
+			instance = new ModelManager(managerName);
 		}
 		return instance;
 	}
 	
-	private ModelManager()
+	private ModelManager(String managerName)
 	{
-		modelRetriever = ModelRetrieverFactory.getInstance().getEntityManager();
+		modelRetriever = ModelRetrieverFactory.getInstance().getEntityManager(managerName);
 	}
 	
 	/**

--- a/AOMRoleMapper/src/org/esfinge/aom/model/rolemapper/core/AdapterEntity.java
+++ b/AOMRoleMapper/src/org/esfinge/aom/model/rolemapper/core/AdapterEntity.java
@@ -227,8 +227,10 @@ public class AdapterEntity implements IEntity {
 				{
 					if(entityDescriptor.getMapPropertiesDescriptor() != null){
 						Method getPropertiesMethod = entityDescriptor.getMapPropertiesDescriptor().getGetFieldMethod();
-						Map dsMapProperties = (Map<String,?>) getPropertiesMethod.invoke(dsObject);					
-						dsMapProperties.replace(propertyName, propertyValue);
+						Map dsMapProperties = (Map<String,?>) getPropertiesMethod.invoke(dsObject);
+						if (dsMapProperties.containsKey(propertyName)) {
+							dsMapProperties.put(propertyName, propertyValue);
+						}
 					}
 					property.setValue(propertyValue);
 					return;


### PR DESCRIPTION
O método Map.replace foi introduzido no Java 8 ([documentação](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#replace-K-V-)). Substitui a chamada ao método pela implementação que consta na documentação acima para manter a compatibilidade com o Java 7.